### PR TITLE
Upgrade from javax.servlet to jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>csiro.pidsvc</groupId>
 	<artifactId>pidsvc</artifactId>
 	<packaging>war</packaging>
-	<version>1.3-SNAPSHOT</version>
+	<version>2.0-SNAPSHOT</version>
 	<name>Persistent Identifiers PID Service (PID Service)</name>
 	<url>https://confluence.csiro.au/x/9ZMKGg</url>
 	<licenses>
@@ -14,9 +14,9 @@
 		</license>
 	</licenses>
 	<scm>
-		<connection>scm:git:git://github.com:SISS/PID.git</connection>
-        <developerConnection>scm:git:git://github.com:SISS/PID.git</developerConnection>
-        <url>scm:git:https://github.com/SISS/PID</url>
+		<connection>scm:git:git://github.com:nlsfi/PID.git</connection>
+        <developerConnection>scm:git:git://github.com:nlsfi/PID.git</developerConnection>
+        <url>scm:git:https://github.com/nlsfi/PID</url>
 	</scm>
 	<ciManagement>
 		<system>Jenkins</system>
@@ -30,10 +30,10 @@
 		<!-- finalName>${project.artifactId}-${project.version}.${buildNumber}</finalName -->
 		<!-- Overridable with: mvn -DfinalName=something_else clean install -->
 		<finalName>${project.artifactId}</finalName>
-		<jdk.release.version>11</jdk.release.version>
-        <log4j.version>2.23.1</log4j.version>
+		<jdk.release.version>21</jdk.release.version>
+        <log4j.version>2.25.2</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <postgresql.version>42.7.3</postgresql.version>
+        <postgresql.version>42.7.8</postgresql.version>
 		<postgres.jdbc.scope>provided</postgres.jdbc.scope>
 		<version.check.repository>https://cgsrv1.arrc.csiro.au/swrepo/PidService/jenkins/master/</version.check.repository>
 	</properties>
@@ -173,9 +173,10 @@
 	<dependencies>
 		<!-- Servlets 2.3 - JSTL 1.1 -->
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.4</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+			<version>6.0.0</version>
+			<scope>provided</scope>
 		</dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -197,7 +198,7 @@
 		<dependency>
 			<groupId>net.sf.saxon</groupId>
 			<artifactId>Saxon-HE</artifactId>
-			<version>12.5</version>
+			<version>12.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
@@ -218,27 +219,27 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.16.0</version>
+			<version>3.20.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.16.1</version>
+			<version>2.21.0</version>
 		</dependency>
 		<dependency>
-			<groupId>commons-fileupload</groupId>
-			<artifactId>commons-fileupload</artifactId>
-			<version>1.5</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
+			<version>2.0.0-M4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.zxing</groupId>
 			<artifactId>core</artifactId>
-			<version>3.5.3</version>
+			<version>3.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.zxing</groupId>
 			<artifactId>javase</artifactId>
-			<version>3.5.3</version>
+			<version>3.5.4</version>
 		</dependency>
         <dependency>
             <groupId>org.jmock</groupId>

--- a/src/main/java/csiro/pidsvc/core/Settings.java
+++ b/src/main/java/csiro/pidsvc/core/Settings.java
@@ -23,9 +23,9 @@ import java.util.regex.Pattern;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServlet;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/csiro/pidsvc/helper/Http.java
+++ b/src/main/java/csiro/pidsvc/helper/Http.java
@@ -14,8 +14,8 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;

--- a/src/main/java/csiro/pidsvc/mappingstore/FormalGrammar.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/FormalGrammar.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/csiro/pidsvc/mappingstore/Manager.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/Manager.java
@@ -18,6 +18,8 @@ import java.io.StringWriter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -34,7 +36,7 @@ import java.util.zip.GZIPInputStream;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import javax.sql.DataSource;
 import javax.xml.XMLConstants;
 import jakarta.xml.bind.ValidationException;
@@ -59,10 +61,10 @@ import net.sf.saxon.s9api.XsltTransformer;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.StringUtils;
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.disk.DiskFileItem;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.fileupload2.core.FileItem;
+import org.apache.commons.fileupload2.core.FileUploadException;
+import org.apache.commons.fileupload2.core.DiskFileItemFactory;
+import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -93,6 +95,11 @@ public class Manager
 
 	protected Connection	_connection = null;
 	private String 			_authorizationName = null;
+    private static final int KB = 1024;
+    private static final int MB = 1024 * KB;
+
+    // Store files smaller than 128kb in memory instead of writing them to disk
+    private static final int MAX_SIZE_MEMORY = 128 * KB;
 
 	public class MappingMatchResults
 	{
@@ -329,6 +336,7 @@ public class Manager
 		return null;
 	}
 
+
 	@SuppressWarnings("unchecked")
 	protected String unwrapCompressedBackupFile(HttpServletRequest request, ICallback callback)
 	{
@@ -338,18 +346,17 @@ public class Manager
 
 		try
 		{
-			DiskFileItemFactory fileItemFactory = new DiskFileItemFactory();
+			// DiskFileItemFactory fileItemFactory = new DiskFileItemFactory();
+			Path tempDir = Paths.get(System.getProperty("java.io.tmpdir"));
+			DiskFileItemFactory diskFileItemFactory = DiskFileItemFactory.builder()
+				.setPath(tempDir)
+				.setBufferSize(MAX_SIZE_MEMORY).get();
 
-			// Set the size threshold, above which content will be stored on disk.
-			fileItemFactory.setSizeThreshold(1 * 1024 * 1024); // 1 MB
-//			fileItemFactory.setSizeThreshold(100 * 1024); // 100 KB
+            JakartaServletFileUpload upload = new JakartaServletFileUpload(diskFileItemFactory);
+			upload.setSizeMax(1 * MB); // 1 MB
+// 			ServletFileUpload uploadHandler = new ServletFileUpload(fileItemFactory);
 
-			// Set the temporary directory to store the uploaded files of size above threshold.
-			fileItemFactory.setRepository(new File(System.getProperty("java.io.tmpdir")));
-
-			ServletFileUpload uploadHandler = new ServletFileUpload(fileItemFactory);
-
-			fileList = uploadHandler.parseRequest(request);
+			fileList = upload.parseRequest(request);
 			for (FileItem item : fileList)
 			{
 				if (item.isFormField())
@@ -405,8 +412,13 @@ public class Manager
 				// Delete all uploaded files.
 				for (FileItem item : fileList)
 				{
-					if (!item.isFormField() && !item.isInMemory())
-						((DiskFileItem)item).delete();
+					if (!item.isFormField() && !item.isInMemory()) {
+						try {
+							item.delete();
+						} catch (Exception e) {
+							_logger.warn("Unable to delete file.");
+						}
+					}
 				}
 			}
 		}

--- a/src/main/java/csiro/pidsvc/mappingstore/ManagerJson.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/ManagerJson.java
@@ -19,7 +19,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.naming.NamingException;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/csiro/pidsvc/mappingstore/action/ActionProxy.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/action/ActionProxy.java
@@ -12,8 +12,8 @@ package csiro.pidsvc.mappingstore.action;
 
 import java.util.HashMap;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;

--- a/src/main/java/csiro/pidsvc/mappingstore/action/ActionQrCode.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/action/ActionQrCode.java
@@ -13,8 +13,8 @@ package csiro.pidsvc.mappingstore.action;
 import java.io.IOException;
 import java.util.Hashtable;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/csiro/pidsvc/mappingstore/action/Runner.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/action/Runner.java
@@ -17,8 +17,8 @@ import java.util.Enumeration;
 import java.util.HashMap;
 
 import javax.naming.NamingException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/csiro/pidsvc/mappingstore/condition/AbstractCondition.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/condition/AbstractCondition.java
@@ -13,7 +13,7 @@ package csiro.pidsvc.mappingstore.condition;
 import java.util.HashMap;
 import java.util.regex.Matcher;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import csiro.pidsvc.helper.URI;
 

--- a/src/main/java/csiro/pidsvc/mappingstore/condition/AbstractConditionCollectionSearch.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/condition/AbstractConditionCollectionSearch.java
@@ -13,7 +13,7 @@ package csiro.pidsvc.mappingstore.condition;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import csiro.pidsvc.helper.URI;
 

--- a/src/main/java/csiro/pidsvc/mappingstore/condition/AbstractConditionComparator.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/condition/AbstractConditionComparator.java
@@ -10,7 +10,7 @@
 
 package csiro.pidsvc.mappingstore.condition;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import csiro.pidsvc.helper.URI;
 import csiro.pidsvc.mappingstore.FormalGrammar;

--- a/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionComparator.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionComparator.java
@@ -10,7 +10,7 @@
 
 package csiro.pidsvc.mappingstore.condition;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import csiro.pidsvc.helper.URI;
 

--- a/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionComparatorI.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionComparatorI.java
@@ -10,7 +10,7 @@
 
 package csiro.pidsvc.mappingstore.condition;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import csiro.pidsvc.helper.URI;
 

--- a/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionContentType.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionContentType.java
@@ -15,7 +15,7 @@ import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import csiro.pidsvc.helper.URI;
 import csiro.pidsvc.mappingstore.condition.helper.PrioritizedQueue;

--- a/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionExtension.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionExtension.java
@@ -13,7 +13,7 @@ package csiro.pidsvc.mappingstore.condition;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import csiro.pidsvc.helper.URI;
 

--- a/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionHttpHeader.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionHttpHeader.java
@@ -10,7 +10,7 @@
 
 package csiro.pidsvc.mappingstore.condition;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import csiro.pidsvc.helper.URI;
 

--- a/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionQrCodeRequest.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionQrCodeRequest.java
@@ -10,7 +10,7 @@
 
 package csiro.pidsvc.mappingstore.condition;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import csiro.pidsvc.helper.URI;
 

--- a/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionQueryString.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/condition/ConditionQueryString.java
@@ -10,7 +10,7 @@
 
 package csiro.pidsvc.mappingstore.condition;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import csiro.pidsvc.helper.URI;
 

--- a/src/main/java/csiro/pidsvc/servlet/controller.java
+++ b/src/main/java/csiro/pidsvc/servlet/controller.java
@@ -16,10 +16,10 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.zip.GZIPOutputStream;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/csiro/pidsvc/servlet/dispatcher.java
+++ b/src/main/java/csiro/pidsvc/servlet/dispatcher.java
@@ -13,12 +13,12 @@ package csiro.pidsvc.servlet;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/csiro/pidsvc/servlet/info.java
+++ b/src/main/java/csiro/pidsvc/servlet/info.java
@@ -14,10 +14,10 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Enumeration;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/csiro/pidsvc/servlet/schemas.java
+++ b/src/main/java/csiro/pidsvc/servlet/schemas.java
@@ -12,10 +12,10 @@ package csiro.pidsvc.servlet;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/test/java/csiro/pidsvc/mappingstore/TestFormalGrammar.java
+++ b/src/test/java/csiro/pidsvc/mappingstore/TestFormalGrammar.java
@@ -13,7 +13,7 @@ package csiro.pidsvc.mappingstore;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import junit.framework.Assert;
 


### PR DESCRIPTION
Compile with/for Java 21 and Tomcat 10.1.

Fileupload hasn't been tested as the frontend uses a swf/Flash-plugin that hasn't been around for some time now. Probably should just tune the backup/restore UI and replace the swf with a textarea input where user can paste an xml from the backup instead.