### PR TITLE
Allow sending xml-backup from textarea

### DIFF
--- a/src/main/java/csiro/pidsvc/mappingstore/Manager.java
+++ b/src/main/java/csiro/pidsvc/mappingstore/Manager.java
@@ -10,6 +10,7 @@
 
 package csiro.pidsvc.mappingstore;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,6 +21,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -1279,13 +1281,26 @@ public class Manager
 
 	public String importMappings(HttpServletRequest request)
 	{
-		return unwrapCompressedBackupFile(request, new ICallback() {
-			@Override
-			public String process(InputStream inputStream) throws Exception
-			{
-				return createMapping(inputStream, true);
+		String payload = request.getParameter("payload");
+		if (payload != null) {
+			try (ByteArrayInputStream inputStream = new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8))) {
+				String response = createMapping(inputStream, true);
+				_logger.debug(response);
+				return response;
+			} catch (Exception e) {
+				_logger.error(e);
+				// e.printStackTrace();
+				return "";
 			}
-		});
+		} else {
+			return unwrapCompressedBackupFile(request, new ICallback() {
+				@Override
+				public String process(InputStream inputStream) throws Exception
+				{
+					return createMapping(inputStream, true);
+				}
+			});
+		}
 	}
 
 	public String mergeMappingUpload(HttpServletRequest request)

--- a/src/main/webapp/backup.html
+++ b/src/main/webapp/backup.html
@@ -131,8 +131,12 @@
 							irreversible and will cause complete loss of mapping configuration.
 						</div>
 					</div>
-					<div id="swfuploadControl" style="margin: 25px 0 15px 0;">
-						<input type="button" id="UploadButton" />
+					<!-- id="swfuploadControl"  -->
+					<div style="margin: 25px 0 15px 0;">
+						<form method="POST" action="controller?cmd=import">
+							<textarea name="payload"></textarea>
+							<input type="submit" id="UploadButton" />
+						</form>
 					</div>
 					<div style="background: #fafafa; width: 600px; padding-top: 5px; display: none;">
 						<table id="UploadQueue" border="0" cellpadding="5" cellspacing="1" width="600">


### PR DESCRIPTION
The "restore" tab used Flash-plugin for file uploads of backup files. This PR replaces the plugin with a textarea where the xml-contents of a backup file can be pasted and restore can be done that way.